### PR TITLE
Integrate get_oil_type()

### DIFF
--- a/.github/workflows/docs-linkcheck.yaml
+++ b/.github/workflows/docs-linkcheck.yaml
@@ -31,7 +31,7 @@ jobs:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('envs/environment-test.yaml') }}
 
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
            auto-update-conda: true
            auto-activate-base: false

--- a/.github/workflows/pytest-coverage.yaml
+++ b/.github/workflows/pytest-coverage.yaml
@@ -29,7 +29,7 @@ jobs:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('envs/environment-test.yaml') }}
 
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
            auto-update-conda: true
            auto-activate-base: false

--- a/.github/workflows/pytest-coverage.yaml
+++ b/.github/workflows/pytest-coverage.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          author_name: pytest & coverage report
+          author_name: ${{ matrix.python-version }} pytest & coverage report
           fields: repo,eventName,ref,workflow
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SALISHSEACAST_WEBHOOK_URL }}
@@ -61,7 +61,7 @@ jobs:
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          author_name: pytest & coverage report
+          author_name: ${{ matrix.python-version }} pytest & coverage report
           fields: repo,eventName,ref,workflow
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MIDOSS_WEBHOOK_URL }}

--- a/.github/workflows/pytest-coverage.yaml
+++ b/.github/workflows/pytest-coverage.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          author_name: ${{ matrix.python-version }} pytest & coverage report
+          author_name: Python ${{ matrix.python-version }} pytest & coverage report
           fields: repo,eventName,ref,workflow
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SALISHSEACAST_WEBHOOK_URL }}
@@ -61,7 +61,7 @@ jobs:
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          author_name: ${{ matrix.python-version }} pytest & coverage report
+          author_name: Python ${{ matrix.python-version }} pytest & coverage report
           fields: repo,eventName,ref,workflow
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MIDOSS_WEBHOOK_URL }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,12 @@ autodoc_mock_imports = [
     "xarray",
     "yaml",
 ]
+
+# Private GitHub repositories that linkcheck will ignore
+linkcheck_ignore = [
+    "https://github.com/MIDOSS/marine_transport_data",
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/docs/moad_tools.rst
+++ b/docs/moad_tools.rst
@@ -162,7 +162,7 @@ Here is an example YAML file:
       - other
 
     # File to read oil attribution data from
-    oil attribution: /media/doug/warehouse/MIDOSS/marine_transport_data/oil_attribution_example.yaml
+    oil attribution: /media/doug/warehouse/MIDOSS/marine_transport_data/oil_attribution.yaml
 
 
 .. _RandomOilSpillsFunctionsAndCommand-lineInterface:

--- a/moad_tools/midoss/random_oil_spills.py
+++ b/moad_tools/midoss/random_oil_spills.py
@@ -111,6 +111,7 @@ def random_oil_spills(n_spills, config_file, random_seed=None):
             geotiff_y_index,
             random_generator,
         )
+        spill_params["vessel_type"].append(vessel_type)
 
         (
             vessel_len,
@@ -125,6 +126,7 @@ def random_oil_spills(n_spills, config_file, random_seed=None):
             random_generator,
         )
         spill_params["vessel_mmsi"].append(vessel_mmsi)
+
         vessel_len = adjust_tug_tank_barge_length(
             vessel_type, vessel_len, random_generator
         )

--- a/moad_tools/midoss/random_oil_spills.py
+++ b/moad_tools/midoss/random_oil_spills.py
@@ -459,9 +459,15 @@ def get_length_origin_destination(
         )
         vte[i] = frac_in_cell * track_duration.total_seconds()
 
-    chosen_track_index = random_generator.choice(
-        range(len(ais_tracks.index)), p=vte / vte.sum()
-    )
+    try:
+        chosen_track_index = random_generator.choice(
+            range(len(ais_tracks.index)), p=vte / vte.sum()
+        )
+    except ValueError:
+        raise ValueError(
+            f"No AIS tracks in GeoTIFF box: "
+            f"{shapefiles_dir=}, {vessel_type=}, {spill_month=}, {geotiff_bbox.exterior.coords.xy=}"
+        )
     vessel_len = ais_tracks.LENGTH[chosen_track_index]
     try:
         vessel_origin = ais_tracks.FROM_[chosen_track_index]

--- a/moad_tools/midoss/random_oil_spills.py
+++ b/moad_tools/midoss/random_oil_spills.py
@@ -85,7 +85,7 @@ def random_oil_spills(n_spills, config_file, random_seed=None):
 
     spill_params = collections.defaultdict(list)
     for spill in range(n_spills):
-        logging.debug(f"spill number: {spill=}")
+        logging.info(f"spill number: {spill=}")
         spill_date_hour = get_date(
             start_date, end_date, vte_probability, random_generator
         )
@@ -519,7 +519,7 @@ def adjust_tug_tank_barge_length(vessel_type, vessel_len, random_generator):
     """
     logging.info(
         f"Standardizing ATB and tug length to represent length of tug and tank barge "
-        f"for {vessel_len}m {vessel_type}"
+        f"for {vessel_len}m {vessel_type} vessel"
     )
     if vessel_type not in {"atb", "barge"}:
         # Adjustment only applies to ATB and barge vessel types

--- a/moad_tools/midoss/random_oil_spills.py
+++ b/moad_tools/midoss/random_oil_spills.py
@@ -76,6 +76,13 @@ def random_oil_spills(n_spills, config_file, random_seed=None):
 
     shapefiles_dir = Path(config["shapefiles dir"])
 
+    oil_attribution_file = Path(config["oil attribution"])
+
+    marine_transport_data_dir = oil_attribution_file.parent
+
+    with oil_attribution_file.open("rt") as f:
+        oil_attrs = yaml.safe_load(f)
+
     spill_params = collections.defaultdict(list)
     for spill in range(n_spills):
         spill_date_hour = get_date(
@@ -131,9 +138,6 @@ def random_oil_spills(n_spills, config_file, random_seed=None):
             vessel_type, vessel_len, random_generator
         )
 
-        oil_attribution_file = Path(config["oil attribution"])
-        with oil_attribution_file.open("rt") as f:
-            oil_attrs = yaml.safe_load(f)
         fuel_capacity, cargo_capacity = get_oil_capacity(
             oil_attrs, vessel_len, vessel_type, random_generator
         )

--- a/moad_tools/midoss/random_oil_spills.py
+++ b/moad_tools/midoss/random_oil_spills.py
@@ -137,21 +137,13 @@ def random_oil_spills(n_spills, config_file, random_seed=None):
         fuel_capacity, cargo_capacity = get_oil_capacity(
             oil_attrs, vessel_len, vessel_type, random_generator
         )
-        try:
-            fuel_spill = random_generator.choice(
-                [False, True],
-                p=[
-                    oil_attrs["vessel_attributes"][vessel_type]["probability_cargo"],
-                    oil_attrs["vessel_attributes"][vessel_type]["probability_fuel"],
-                ],
-            )
-        except KeyError:
-            # No probability_cargo or probability_fuel key means that vessel type carries only fuel
-            fuel_spill = 1
+
+        fuel_spill = fuel_or_cargo_spill(oil_attrs, vessel_type, random_generator)
         max_spill_volume = fuel_capacity if fuel_spill else cargo_capacity
         spill_params["spill_volume"].append(
             max_spill_volume * choose_fraction_spilled(random_generator)
         )
+        spill_params["fuel_cargo"].append("fuel" if fuel_spill else "cargo")
 
     df = pandas.DataFrame(spill_params)
 
@@ -741,6 +733,34 @@ def _get_bin(value, bins):
         if bins[i][0] <= value < bins[i][1]:
             return i
     return -1
+
+
+def fuel_or_cargo_spill(oil_attrs, vessel_type, random_generator):
+    """Randomly choose whether the spill is from fuel or cargo volume for vessel types that
+    transport oil as cargo.
+
+    :param dict oil_attrs: Oil attribution information from the output of make_oil_attrs.py.
+
+    :param str vessel_type: Vessel type from which spill occurs.
+
+    :param random_generator: PCG-64 random number generator.
+    :type random_generator: :py:class:`numpy.random.Generator`
+
+    :return: Fuel or cargo spill flag.
+    :rtype: boolean
+    """
+    try:
+        fuel_spill = random_generator.choice(
+            [False, True],
+            p=[
+                oil_attrs["vessel_attributes"][vessel_type]["probability_cargo"],
+                oil_attrs["vessel_attributes"][vessel_type]["probability_fuel"],
+            ],
+        )
+    except KeyError:
+        # No probability_cargo or probability_fuel key means that vessel type carries only fuel
+        fuel_spill = True
+    return fuel_spill
 
 
 def choose_fraction_spilled(random_generator):

--- a/moad_tools/midoss/random_oil_spills.py
+++ b/moad_tools/midoss/random_oil_spills.py
@@ -502,9 +502,14 @@ def get_length_origin_destination(
         )
         vte[i] = frac_in_cell * track_duration.total_seconds()
 
-    chosen_track_index = random_generator.choice(
-        range(len(ais_tracks.index)), p=vte / vte.sum()
-    )
+    try:
+        chosen_track_index = random_generator.choice(
+            range(len(ais_tracks.index)), p=vte / vte.sum()
+        )
+    except ValueError:
+        # Handle the corner case of AIS track(s) that graze(s) the bounding box but have zero VTE
+        # in it by using a uniform probability distribution
+        chosen_track_index = random_generator.choice(range(len(ais_tracks.index)))
     vessel_len = ais_tracks.LENGTH[chosen_track_index]
     try:
         vessel_origin = ais_tracks.FROM_[chosen_track_index]

--- a/moad_tools/midoss/random_oil_spills.py
+++ b/moad_tools/midoss/random_oil_spills.py
@@ -1564,6 +1564,8 @@ def cli(n_spills, config_file, csv_file, verbosity):
         datefmt="%Y-%m-%d %H:%M:%S",
         stream=sys.stdout,
     )
+    logging.getLogger("fiona").setLevel(logging.WARNING)
+    logging.getLogger("rasterio").setLevel(logging.WARNING)
     df = random_oil_spills(n_spills, config_file)
     write_csv_file(df, csv_file)
 

--- a/moad_tools/midoss/random_oil_spills.py
+++ b/moad_tools/midoss/random_oil_spills.py
@@ -461,7 +461,7 @@ def get_length_origin_destination(
         # happen because the GeoTIFF calculation algorithm that Cam uses can "smear"
         # vessel traffic exposure into adjacent GoeTIFF cells:
         # Expand the bounding box to capture AIS tracks associated with smeared VTE
-        bbox_increment = 0.5 * (
+        bbox_increment = 0.55 * (
             numpy.abs(geotiff_bbox.bounds[2] - geotiff_bbox.bounds[0])
         )
         geotiff_bbox = shapely.geometry.Polygon(

--- a/moad_tools/midoss/random_oil_spills.py
+++ b/moad_tools/midoss/random_oil_spills.py
@@ -244,7 +244,11 @@ def get_date(start_date, end_date, vte_probability, random_generator):
 
 
 def get_lat_lon_indices(
-    geotiffs_dir, spill_month, geotiff_watermask, ssc_mesh, random_generator,
+    geotiffs_dir,
+    spill_month,
+    geotiff_watermask,
+    ssc_mesh,
+    random_generator,
 ):
     """Randomly select a spill lat/lon based on vessel traffic exposure (VTE)
     in a particular month's AIS GeoTIFF file. The VTE data are masked to include
@@ -324,7 +328,8 @@ def get_lat_lon_indices(
         # SalishSeaCast T-grid points to those that were found above to be within the chosen
         # GeoTIFF cell.
         ssp = random_generator.choice(
-            ssc_tmask.size, p=inner_points.flatten() / inner_points.sum(),
+            ssc_tmask.size,
+            p=inner_points.flatten() / inner_points.sum(),
         )
         sslon = ssc_lons.values.flat[ssp]
         sslat = ssc_lats.values.flat[ssp]
@@ -418,7 +423,11 @@ def get_vessel_type(
 
 
 def get_length_origin_destination(
-    shapefiles_dir, vessel_type, spill_month, geotiff_bbox, random_generator,
+    shapefiles_dir,
+    vessel_type,
+    spill_month,
+    geotiff_bbox,
+    random_generator,
 ):
     """Randomly choose an AIS vessel track from which the spill occurs, with the choice
     weighted by the vessel traffic exposure (VTE) for the specified vessel type, month,
@@ -920,7 +929,8 @@ def get_oil_type(
 
     if fuel_spill:
         oil_type = random_generator.choice(
-            ["bunker", "diesel"], p=raw_fuel_type_probs / raw_fuel_type_probs.sum(),
+            ["bunker", "diesel"],
+            p=raw_fuel_type_probs / raw_fuel_type_probs.sum(),
         )
     else:
         if vessel_type == "atb":

--- a/moad_tools/midoss/random_oil_spills.py
+++ b/moad_tools/midoss/random_oil_spills.py
@@ -964,7 +964,7 @@ def get_oil_type_atb(
     Unlike traditional tank barges, the vessels with 'atb' designation are known oil-cargo vessels.
     We used three different data sources to verify: AIS, Dept of Ecology's fuel transfer records
     and Charlie Costanzo's ATB list. Details of traffic can be seen in this google spreadsheet:
-    https://docs.google.com/spreadsheets/d/1dlT0JydkFG43LorqgtHle5IN6caRYjf_3qLrUYqANDY/edit#gid=1593104354
+    https://docs.google.com/spreadsheets/d/1dlT0JydkFG43LorqgtHle5IN6caRYjf_3qLrUYqANDY/edit
 
     Because of this pre-identification and selection method, we can assume that all ATBs are
     oil-cargo atbs and that the absence of origin-destination information is due to issues in

--- a/moad_tools/midoss/random_oil_spills.py
+++ b/moad_tools/midoss/random_oil_spills.py
@@ -1009,14 +1009,16 @@ def get_oil_type_atb(
     yaml_file = transport_data_dir / Path(oil_attrs["files"]["WA_destination"]).name
     with yaml_file.open("rt") as f:
         WA_in_yaml = yaml.safe_load(f)
+        WA_in_noinfo = _calc_no_info_facilities(WA_in_yaml)
     yaml_file = transport_data_dir / Path(oil_attrs["files"]["WA_origin"]).name
     with yaml_file.open("rt") as f:
         WA_out_yaml = yaml.safe_load(f)
-    # # US_origin is for US as origin
+        WA_out_noinfo = _calc_no_info_facilities(WA_out_yaml)
+    # US_origin is for US as origin
     yaml_file = transport_data_dir / Path(oil_attrs["files"]["US_origin"]).name
     with yaml_file.open("rt") as f:
         US_yaml = yaml.safe_load(f)
-    # # US_combined represents the combined import and export of oil
+    # US_combined represents the combined import and export of oil
     yaml_file = transport_data_dir / Path(oil_attrs["files"]["US_combined"]).name
     with yaml_file.open("rt") as f:
         USall_yaml = yaml.safe_load(f)
@@ -1069,7 +1071,7 @@ def get_oil_type_atb(
                 oil_type = get_oil_type_cargo(
                     CAD_yaml, origin, vessel_type, random_generator
                 )
-    elif origin in US_origin_destination:
+    elif origin in US_origin_destination and origin not in WA_out_noinfo[vessel_type]:
         if destination == "Westridge Marine Terminal":
             # Westridge stores jet fuel from US for re-distribution
             oil_type = "jet"
@@ -1077,7 +1079,10 @@ def get_oil_type_atb(
             oil_type = get_oil_type_cargo(
                 WA_out_yaml, origin, vessel_type, random_generator
             )
-    elif destination in US_origin_destination:
+    elif (
+        destination in US_origin_destination
+        and destination not in WA_in_noinfo[vessel_type]
+    ):
         oil_type = get_oil_type_cargo(
             WA_in_yaml, destination, vessel_type, random_generator
         )
@@ -1164,14 +1169,16 @@ def get_oil_type_barge(
     yaml_file = transport_data_dir / Path(oil_attrs["files"]["WA_destination"]).name
     with yaml_file.open("rt") as f:
         WA_in_yaml = yaml.safe_load(f)
+        WA_in_noinfo = _calc_no_info_facilities(WA_in_yaml)
     yaml_file = transport_data_dir / Path(oil_attrs["files"]["WA_origin"]).name
     with yaml_file.open("rt") as f:
         WA_out_yaml = yaml.safe_load(f)
-    # # US_origin is for US as origin
+        WA_out_noinfo = _calc_no_info_facilities(WA_out_yaml)
+    # US_origin is for US as origin
     yaml_file = transport_data_dir / Path(oil_attrs["files"]["US_origin"]).name
     with yaml_file.open("rt") as f:
         US_yaml = yaml.safe_load(f)
-    # # US_combined represents the combined import and export of oil
+    # US_combined represents the combined import and export of oil
     yaml_file = transport_data_dir / Path(oil_attrs["files"]["US_combined"]).name
     with yaml_file.open("rt") as f:
         USall_yaml = yaml.safe_load(f)
@@ -1255,7 +1262,7 @@ def get_oil_type_barge(
                 # destination and no destination to a better known
                 # CAD terminal then just use the CAD origin allocation
                 # An option here is to flag a destination of 'Pacific'
-                # or 'US' and use US fuel alloction. I didn't see a
+                # or 'US' and use US fuel allocation. I didn't see a
                 # compelling case for adding this complexity, so I kept
                 # it simple.  Similar to ESSO, above, no error catch
                 # needed.
@@ -1264,7 +1271,7 @@ def get_oil_type_barge(
                     CAD_yaml, origin, vessel_type, random_generator
                 )
 
-    elif origin in US_origin_destination:
+    elif origin in US_origin_destination and origin not in WA_out_noinfo[vessel_type]:
         oil_type = get_oil_type_cargo(
             WA_out_yaml, origin, vessel_type, random_generator
         )
@@ -1282,7 +1289,10 @@ def get_oil_type_barge(
             oil_type = None
         # *** END ERROR CATCH ***
 
-    elif destination in US_origin_destination:
+    elif (
+        destination in US_origin_destination
+        and destination not in WA_in_noinfo[vessel_type]
+    ):
         oil_type = get_oil_type_cargo(
             WA_in_yaml, destination, vessel_type, random_generator
         )
@@ -1349,14 +1359,13 @@ def get_oil_type_barge(
         )
         if fuel_spill:
             oil_type = None
-
         else:
             oil_type = get_oil_type_cargo(US_yaml, None, vessel_type, random_generator)
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Remaining cases have null values for origin destination.
     # I first use probability of oil-cargo for tank barge traffic to
-    # weight whether the ship track is an oil-carge & fuel spill risk
+    # weight whether the ship track is an oil-cargo & fuel spill risk
     # (fuel_spill = False) or a fuel-spill risk only (fuel_spill = True)
     # For the cases in which fuel_spill is False, I use the US_generic fuel allocation
     # to attribute fuel type.
@@ -1413,14 +1422,16 @@ def get_oil_type_tanker(
     yaml_file = transport_data_dir / Path(oil_attrs["files"]["WA_destination"]).name
     with yaml_file.open("rt") as f:
         WA_in_yaml = yaml.safe_load(f)
+        WA_in_noinfo = _calc_no_info_facilities(WA_in_yaml)
     yaml_file = transport_data_dir / Path(oil_attrs["files"]["WA_origin"]).name
     with yaml_file.open("rt") as f:
         WA_out_yaml = yaml.safe_load(f)
-    # # US_origin is for US as origin
+        WA_out_noinfo = _calc_no_info_facilities(WA_out_yaml)
+    # US_origin is for US as origin
     yaml_file = transport_data_dir / Path(oil_attrs["files"]["US_origin"]).name
     with yaml_file.open("rt") as f:
         US_yaml = yaml.safe_load(f)
-    # # US_combined represents the combined import and export of oil
+    # US_combined represents the combined import and export of oil
     yaml_file = transport_data_dir / Path(oil_attrs["files"]["US_combined"]).name
     with yaml_file.open("rt") as f:
         USall_yaml = yaml.safe_load(f)
@@ -1451,11 +1462,14 @@ def get_oil_type_tanker(
                 oil_type = get_oil_type_cargo(
                     CAD_yaml, origin, vessel_type, random_generator
                 )
-    elif origin in US_origin_destination:
+    elif origin in US_origin_destination and origin not in WA_out_noinfo[vessel_type]:
         oil_type = get_oil_type_cargo(
             WA_out_yaml, origin, vessel_type, random_generator
         )
-    elif destination in US_origin_destination:
+    elif (
+        destination in US_origin_destination
+        and destination not in WA_in_noinfo[vessel_type]
+    ):
         oil_type = get_oil_type_cargo(
             WA_in_yaml, destination, vessel_type, random_generator
         )
@@ -1469,10 +1483,40 @@ def get_oil_type_tanker(
         oil_type = get_oil_type_cargo(US_yaml, None, vessel_type, random_generator)
     else:
         # Currently, this is a catch for all ship tracks not allocated with origin or destination
-        # It's a generic fuel attribution from the combined US import and export
+        # It's a generic oil type attribution from the combined US import and export
         oil_type = get_oil_type_cargo(USall_yaml, None, vessel_type, random_generator)
 
     return oil_type
+
+
+def _calc_no_info_facilities(oil_xfer_info):
+    """Calculate vessel type keyed dict of lists of facilities for which there is
+    no oil transfer data.
+
+    :param dict oil_xfer_info: Oil transfer information from regional oil attribution YAML file.
+
+    :return: Dictionary of lists of facilities for which there is no oil transfer data,
+             keyed by vessel type
+    :rtype: dict
+    """
+    no_info_facilities = collections.defaultdict(list)
+    for facility in oil_xfer_info:
+        for vessel_type in oil_xfer_info[facility]:
+            try:
+                transfers = sum(
+                    [
+                        oil_xfer_info[facility][vessel_type][oil_type][
+                            "number_of_transfers"
+                        ]
+                        for oil_type in oil_xfer_info[facility][vessel_type]
+                    ]
+                )
+            except TypeError:
+                # Handle "names" stanza in YAML
+                continue
+            if transfers == 0:
+                no_info_facilities[vessel_type].append(facility)
+    return no_info_facilities
 
 
 def get_oil_type_cargo(cargo_info, facility, vessel_type, random_generator):

--- a/tests/test_data/random_oil_spills/fuel_by_vessel.yaml
+++ b/tests/test_data/random_oil_spills/fuel_by_vessel.yaml
@@ -1,0 +1,27 @@
+atb:
+  bunker: 0.38
+  diesel: 0.62
+barge:
+  bunker: 0.38
+  diesel: 0.62
+cargo:
+  bunker: 0.97
+  diesel: 0.03
+cruise:
+  bunker: 0.8
+  diesel: 0.2
+ferry:
+  bunker: 0.0
+  diesel: 1.0
+fishing:
+  bunker: 0.14
+  diesel: 0.86
+other:
+  bunker: 0.32
+  diesel: 0.68
+smallpass:
+  bunker: 0.0
+  diesel: 1.0
+tanker:
+  bunker: 0.64
+  diesel: 0.36

--- a/tests/test_random_oil_spills.py
+++ b/tests/test_random_oil_spills.py
@@ -94,7 +94,11 @@ def mock_calc_vte_probability(monkeypatch):
 @pytest.fixture
 def mock_get_length_origin_destination(monkeypatch):
     def get_length_origin_destination(
-        shapefiles_dir, vessel_type, spill_month, geotiff_bbox, random_generator,
+        shapefiles_dir,
+        vessel_type,
+        spill_month,
+        geotiff_bbox,
+        random_generator,
     ):
         return 16, None, None, "367704540"
 
@@ -106,8 +110,7 @@ def mock_get_length_origin_destination(monkeypatch):
 
 
 class TestRandomOilSpills:
-    """Unit tests for random_oil_spills() function.
-    """
+    """Unit tests for random_oil_spills() function."""
 
     def test_read_config(
         self,
@@ -197,8 +200,7 @@ class TestRandomOilSpills:
 
 
 class TestGetDate:
-    """Unit test for get_date() function.
-    """
+    """Unit test for get_date() function."""
 
     def test_get_date(self, mock_calc_vte_probability):
         start_date = arrow.get("2015-01-01").datetime
@@ -215,8 +217,7 @@ class TestGetDate:
 
 
 class TestGetLatLonIndices:
-    """Unit test for get_lat_lon_indices() function.
-    """
+    """Unit test for get_lat_lon_indices() function."""
 
     def test_get_lat_lon_indices(self, config_file):
         with Path(config_file).open("r") as f:
@@ -269,8 +270,7 @@ class TestGetLatLonIndices:
 
 
 class TestGetVesselType:
-    """Unit tests for get_vessel_type() function.
-    """
+    """Unit tests for get_vessel_type() function."""
 
     def test_get_vessel_type(self, config_file):
         with Path(config_file).open("r") as f:
@@ -296,8 +296,7 @@ class TestGetVesselType:
 
 
 class TestGetLengthOriginDestination:
-    """Unit test for get_length_origin_destination() function.
-    """
+    """Unit test for get_length_origin_destination() function."""
 
     @pytest.mark.skipif(
         not Path(__file__)
@@ -340,8 +339,7 @@ class TestGetLengthOriginDestination:
 
 
 class TestAdjustTugTankBargeLength:
-    """Unit tests for adjust_tug_tank_barge_length() function.
-    """
+    """Unit tests for adjust_tug_tank_barge_length() function."""
 
     @pytest.mark.parametrize(
         "vessel_type, vessel_len",
@@ -361,25 +359,34 @@ class TestAdjustTugTankBargeLength:
         random_generator = numpy.random.default_rng()
 
         vessel_len = random_oil_spills.adjust_tug_tank_barge_length(
-            vessel_type, vessel_len, random_generator,
+            vessel_type,
+            vessel_len,
+            random_generator,
         )
 
         assert vessel_len == vessel_len
 
-    @pytest.mark.parametrize("vessel_type, vessel_len", (("atb", 43), ("barge", 34),))
+    @pytest.mark.parametrize(
+        "vessel_type, vessel_len",
+        (
+            ("atb", 43),
+            ("barge", 34),
+        ),
+    )
     def test_adjustment(self, vessel_type, vessel_len):
         random_generator = numpy.random.default_rng()
 
         vessel_len = random_oil_spills.adjust_tug_tank_barge_length(
-            vessel_type, vessel_len, random_generator,
+            vessel_type,
+            vessel_len,
+            random_generator,
         )
 
         assert vessel_len in [147, 172, 178, 206, 207]
 
 
 class TestGetOilCapacity:
-    """Unit test for get_oil_capacity() function.
-    """
+    """Unit test for get_oil_capacity() function."""
 
     def test_get_oil_capacity(self, config_file):
         with Path(config_file).open("r") as f:
@@ -458,7 +465,12 @@ class TestGetOilCapacity:
         assert fuel_capacity == oil_attrs["vessel_attributes"][vessel_type]["max_fuel"]
 
     @pytest.mark.parametrize(
-        "vessel_type, vessel_len", (("tanker", 0.10), ("atb", 0.10), ("barge", 0.10),)
+        "vessel_type, vessel_len",
+        (
+            ("tanker", 0.10),
+            ("atb", 0.10),
+            ("barge", 0.10),
+        ),
     )
     def test_min_cargo_capacity(self, vessel_type, vessel_len, config_file):
         with Path(config_file).open("r") as f:
@@ -479,7 +491,11 @@ class TestGetOilCapacity:
 
     @pytest.mark.parametrize(
         "vessel_type, vessel_len",
-        (("tanker", 1_000_000), ("atb", 1_000_000), ("barge", 1_000_000),),
+        (
+            ("tanker", 1_000_000),
+            ("atb", 1_000_000),
+            ("barge", 1_000_000),
+        ),
     )
     def test_max_cargo_capacity(self, vessel_type, vessel_len, config_file):
         with Path(config_file).open("r") as f:
@@ -500,8 +516,7 @@ class TestGetOilCapacity:
 
 
 class TestFuelOrCargoSpill:
-    """Unit tests for fuel_or_cargo_spill() function.
-    """
+    """Unit tests for fuel_or_cargo_spill() function."""
 
     @pytest.mark.parametrize(
         "vessel_type, random_seed, expected",
@@ -544,8 +559,7 @@ class TestFuelOrCargoSpill:
 
 
 class TestChooseFractionSpilled:
-    """Unit test for choose_fraction_spilled() function.
-    """
+    """Unit test for choose_fraction_spilled() function."""
 
     def test_choose_fraction_spilled(self):
         # Specifying the random seed makes the random number stream deterministic
@@ -558,8 +572,7 @@ class TestChooseFractionSpilled:
 
 
 class TestCumulativeSpillFraction:
-    """Unit test for _cumulative_spill_fraction() function.
-    """
+    """Unit test for _cumulative_spill_fraction() function."""
 
     def test_cumulative_spill_fraction(self):
         nbins = 50
@@ -626,8 +639,7 @@ class TestCumulativeSpillFraction:
 
 
 class TestGetOilType:
-    """Unit tests for get_oil_type() function.
-    """
+    """Unit tests for get_oil_type() function."""
 
     @pytest.mark.parametrize(
         "vessel_type, expected",
@@ -920,8 +932,7 @@ class TestGetOilTypeCargo:
 
 
 class TestWriteCSVFile:
-    """Unit test for write_csv_file() function.
-    """
+    """Unit test for write_csv_file() function."""
 
     def test_write_csv_file(self, tmp_path):
         df = pandas.DataFrame(

--- a/tests/test_random_oil_spills.py
+++ b/tests/test_random_oil_spills.py
@@ -150,19 +150,15 @@ class TestRandomOilSpills:
                 "spill_lat": [50.40640],
                 "geotiff_x_index": [134],
                 "geotiff_y_index": [393],
-                "vessel_type": "other",
+                "vessel_type": ["other"],
                 "vessel_mmsi": ["367704540"],
                 "spill_volume": [13.95439],
-                "fuel_cargo": "fuel",
-                "Lagrangian_template": "Lagrangian_diesel.dat",
+                "fuel_cargo": ["fuel"],
+                "Lagrangian_template": ["Lagrangian_diesel.dat"],
             }
         )
         pandas.testing.assert_frame_equal(df, expected)
 
-    @pytest.mark.xfail(
-        reason="2nd dataframe row changes every time a random_generator.choice() call is added; "
-        "finalize when script is complete"
-    )
     def test_dataframe_two_rows(
         self,
         mock_calc_vte_probability,
@@ -174,19 +170,27 @@ class TestRandomOilSpills:
     ):
         # Specifying the random seed makes the random number stream deterministic
         # so that calculated results are repeatable
-        df = random_oil_spills.random_oil_spills(2, config_file, random_seed=43)
+        df = random_oil_spills.random_oil_spills(2, config_file, random_seed=45)
 
         expected = pandas.DataFrame(
             {
                 "spill_date_hour": [
-                    pandas.Timestamp(arrow.get("2016-08-19 18:00").datetime),
-                    pandas.Timestamp(arrow.get("2018-08-27 15:00").datetime),
+                    pandas.Timestamp(arrow.get("2017-08-29 17:00").datetime),
+                    pandas.Timestamp(arrow.get("2016-08-04 22:00").datetime),
                 ],
                 "run_days": [7, 7],
-                "spill_lon": [-124.6175, -123.0092],
-                "spill_lat": [50.4064, 48.5654],
-                "geotiff_x_index": [134, 256],
-                "geotiff_y_index": [393, 500],
+                "spill_lon": [-122.8388, -123.0017],
+                "spill_lat": [48.5604, 48.7390],
+                "geotiff_x_index": [257, 245],
+                "geotiff_y_index": [511, 500],
+                "vessel_type": ["ferry", "other"],
+                "vessel_mmsi": ["367704540", "367704540"],
+                "spill_volume": [9300.0, 348.85994097108437],
+                "fuel_cargo": ["fuel", "fuel"],
+                "Lagrangian_template": [
+                    "Lagrangian_diesel.dat",
+                    "Lagrangian_diesel.dat",
+                ],
             },
         )
         pandas.testing.assert_frame_equal(df, expected)

--- a/tests/test_random_oil_spills.py
+++ b/tests/test_random_oil_spills.py
@@ -853,14 +853,16 @@ class TestGetOilType:
 
 
 class TestGetOilTypeCargo:
-    """Unit tests for get_oil_type_cargo() function.
-    """
+    """Unit tests for get_oil_type_cargo() function."""
 
     @pytest.mark.parametrize(
         "vessel_type, random_seed, expected",
-        (("atb", 43, "dilbit"), ("atb", 4344, "akns"),),
+        (
+            ("atb", 43, "dilbit"),
+            ("atb", 4344, "akns"),
+        ),
     )
-    def test_get_oil_type_cargo(self, vessel_type, random_seed, expected):
+    def test_get_oil_type_cargo_for_facility(self, vessel_type, random_seed, expected):
         # Specifying the random seed makes the random number stream deterministic
         # so that calculated results are repeatable
         random_generator = numpy.random.default_rng(seed=random_seed)
@@ -885,11 +887,6 @@ class TestGetOilTypeCargo:
 
         assert oil_type == expected
 
-
-class TestGetOilTypeCargoGenericUS:
-    """Unit tests for get_oil_type_cargo_generic_US() function.
-    """
-
     @pytest.mark.parametrize(
         "vessel_type, random_seed, expected",
         (
@@ -899,7 +896,7 @@ class TestGetOilTypeCargoGenericUS:
             ("atb", 4, "jet"),
         ),
     )
-    def test_get_oil_type_cargo_generic_US(self, vessel_type, random_seed, expected):
+    def test_get_oil_type_cargo_no_facility(self, vessel_type, random_seed, expected):
         # Specifying the random seed makes the random number stream deterministic
         # so that calculated results are repeatable
         random_generator = numpy.random.default_rng(seed=random_seed)
@@ -915,8 +912,8 @@ class TestGetOilTypeCargoGenericUS:
                 "other": {"fraction_of_total": 0.0389},
             }
         }
-        oil_type = random_oil_spills.get_oil_type_cargo_generic_US(
-            cargo_info, vessel_type, random_generator
+        oil_type = random_oil_spills.get_oil_type_cargo(
+            cargo_info, None, vessel_type, random_generator
         )
 
         assert oil_type == expected

--- a/tests/test_random_oil_spills.py
+++ b/tests/test_random_oil_spills.py
@@ -150,6 +150,7 @@ class TestRandomOilSpills:
                 "spill_lat": [50.40640],
                 "geotiff_x_index": [134],
                 "geotiff_y_index": [393],
+                "vessel_type": "other",
                 "vessel_mmsi": ["367704540"],
                 "spill_volume": [13.95439],
             }

--- a/tests/test_random_oil_spills.py
+++ b/tests/test_random_oil_spills.py
@@ -668,7 +668,12 @@ class TestGetOilType:
 
     @pytest.mark.parametrize(
         "vessel_type, random_seed, expected",
-        (("atb", 43, "dilbit"), ("atb", 4344, "akns"),),
+        (
+            ("atb", 43, "dilbit"),
+            ("atb", 4344, "akns"),
+            ("tanker", 43, "dilbit"),
+            ("tanker", 4344, "akns"),
+        ),
     )
     def test_get_oil_type_cargo_spill(
         self, vessel_type, random_seed, expected, config_file, tmp_path, monkeypatch
@@ -700,6 +705,22 @@ class TestGetOilType:
                 """\
                 Westridge Marine Terminal:
                   atb:
+                    akns:
+                      fraction_of_total: 0.5
+                    bunker:
+                      fraction_of_total: 0
+                    diesel:
+                      fraction_of_total: 0
+                    dilbit:
+                      fraction_of_total: 0.5
+                    gas:
+                      fraction_of_total: 0
+                    jet:
+                      fraction_of_total: 0
+                    other:
+                      fraction_of_total: 0
+                    
+                  tanker:
                     akns:
                       fraction_of_total: 0.5
                     bunker:

--- a/tests/test_random_oil_spills.py
+++ b/tests/test_random_oil_spills.py
@@ -766,6 +766,13 @@ class TestGetOilType:
         ):
             monkeypatch.setitem(oil_attrs["files"], file_path, empty_file)
 
+        def mock_calc_no_info_facilities(oil_xfer_info):
+            return {}
+
+        monkeypatch.setattr(
+            random_oil_spills, "_calc_no_info_facilities", mock_calc_no_info_facilities
+        )
+
         oil_type = random_oil_spills.get_oil_type(
             oil_attrs,
             vessel_type,
@@ -849,6 +856,13 @@ class TestGetOilType:
             "Pacific_origin",
         ):
             monkeypatch.setitem(oil_attrs["files"], file_path, empty_file)
+
+        def mock_calc_no_info_facilities(oil_xfer_info):
+            return {}
+
+        monkeypatch.setattr(
+            random_oil_spills, "_calc_no_info_facilities", mock_calc_no_info_facilities
+        )
 
         oil_type = random_oil_spills.get_oil_type(
             oil_attrs,

--- a/tests/test_random_oil_spills.py
+++ b/tests/test_random_oil_spills.py
@@ -789,10 +789,10 @@ class TestGetOilType:
     @pytest.mark.parametrize(
         "vessel_origin, vessel_dest, random_seed, expected",
         (
-            ("Westridge Marine Terminal", "Suncor Nanaimo", 43, "jet"),
-            ("Westridge Marine Terminal", "U.S. Oil & Refining", 43, "dilbit"),
-            ("Westridge Marine Terminal", "U.S. Oil & Refining", 4344, "akns"),
-            ("Pacific", None, 43, "bunker"),
+            ("Westridge Marine Terminal", "Suncor Nanaimo", 43, ("jet", False)),
+            ("Westridge Marine Terminal", "U.S. Oil & Refining", 43, ("dilbit", False)),
+            ("Westridge Marine Terminal", "U.S. Oil & Refining", 4344, ("akns", False)),
+            ("Pacific", None, 43, ("bunker", True)),
         ),
     )
     def test_get_oil_type_barge_cargo_spill(

--- a/tests/test_random_oil_spills.py
+++ b/tests/test_random_oil_spills.py
@@ -383,7 +383,7 @@ class TestGetOilCapacity:
         # so that calculated results are repeatable
         random_generator = numpy.random.default_rng(seed=43)
 
-        with Path(config["oil attribution"]).open("r") as f:
+        with Path(config["oil attribution"]).open("rt") as f:
             oil_attrs = yaml.safe_load(f)
         vessel_len = 74
         vessel_type = "cargo"
@@ -415,7 +415,7 @@ class TestGetOilCapacity:
         # so that calculated results are repeatable
         random_generator = numpy.random.default_rng(seed=43)
 
-        with Path(config["oil attribution"]).open("r") as f:
+        with Path(config["oil attribution"]).open("rt") as f:
             oil_attrs = yaml.safe_load(f)
         fuel_capacity, cargo_capacity = random_oil_spills.get_oil_capacity(
             oil_attrs, vessel_len, vessel_type, random_generator
@@ -444,7 +444,7 @@ class TestGetOilCapacity:
         # so that calculated results are repeatable
         random_generator = numpy.random.default_rng(seed=43)
 
-        with Path(config["oil attribution"]).open("r") as f:
+        with Path(config["oil attribution"]).open("rt") as f:
             oil_attrs = yaml.safe_load(f)
         fuel_capacity, cargo_capacity = random_oil_spills.get_oil_capacity(
             oil_attrs, vessel_len, vessel_type, random_generator
@@ -462,7 +462,7 @@ class TestGetOilCapacity:
         # so that calculated results are repeatable
         random_generator = numpy.random.default_rng(seed=43)
 
-        with Path(config["oil attribution"]).open("r") as f:
+        with Path(config["oil attribution"]).open("rt") as f:
             oil_attrs = yaml.safe_load(f)
         fuel_capacity, cargo_capacity = random_oil_spills.get_oil_capacity(
             oil_attrs, vessel_len, vessel_type, random_generator
@@ -483,7 +483,7 @@ class TestGetOilCapacity:
         # so that calculated results are repeatable
         random_generator = numpy.random.default_rng(seed=43)
 
-        with Path(config["oil attribution"]).open("r") as f:
+        with Path(config["oil attribution"]).open("rt") as f:
             oil_attrs = yaml.safe_load(f)
         fuel_capacity, cargo_capacity = random_oil_spills.get_oil_capacity(
             oil_attrs, vessel_len, vessel_type, random_generator
@@ -529,7 +529,7 @@ class TestFuelOrCargoSpill:
         # so that calculated results are repeatable
         random_generator = numpy.random.default_rng(seed=random_seed)
 
-        with Path(config["oil attribution"]).open("r") as f:
+        with Path(config["oil attribution"]).open("rt") as f:
             oil_attrs = yaml.safe_load(f)
         fuel_spill = random_oil_spills.fuel_or_cargo_spill(
             oil_attrs, vessel_type, random_generator

--- a/tests/test_random_oil_spills.py
+++ b/tests/test_random_oil_spills.py
@@ -644,15 +644,15 @@ class TestGetOilType:
     @pytest.mark.parametrize(
         "vessel_type, expected",
         (
-            ("tanker", "diesel"),
-            ("atb", "diesel"),
-            ("barge", "diesel"),
-            ("cargo", "bunker"),
-            ("cruise", "bunker"),
-            ("ferry", "diesel"),
-            ("fishing", "diesel"),
-            ("smallpass", "diesel"),
-            ("other", "diesel"),
+            ("tanker", ("diesel", False)),
+            ("atb", ("diesel", False)),
+            ("barge", ("diesel", False)),
+            ("cargo", ("bunker", False)),
+            ("cruise", ("bunker", False)),
+            ("ferry", ("diesel", False)),
+            ("fishing", ("diesel", False)),
+            ("smallpass", ("diesel", False)),
+            ("other", ("diesel", False)),
         ),
     )
     def test_get_oil_type_fuel_spill(self, vessel_type, expected, config_file):
@@ -685,10 +685,10 @@ class TestGetOilType:
     @pytest.mark.parametrize(
         "vessel_type, random_seed, expected",
         (
-            ("atb", 43, "dilbit"),
-            ("atb", 4344, "akns"),
-            ("tanker", 43, "dilbit"),
-            ("tanker", 4344, "akns"),
+            ("atb", 43, ("dilbit", False)),
+            ("atb", 4344, ("akns", False)),
+            ("tanker", 43, ("dilbit", False)),
+            ("tanker", 4344, ("akns", False)),
         ),
     )
     def test_get_oil_type_atb_tanker_cargo_spill(


### PR DESCRIPTION
Integration of get_oil_type() function from
https://github.com/MIDOSS/analysis-rachael/blob/master/notebooks/monte_carlo/get_oil_type.ipynb.

Also includes debugging of various edge and corner cases in oil type attribution and addition of logging messages to `random-oil-spills` script.