### PR TITLE
Update observations.get_ndbc_buoy()

### DIFF
--- a/moad_tools/observations.py
+++ b/moad_tools/observations.py
@@ -100,9 +100,7 @@ def get_ndbc_buoy(buoy_id):
         logging.error(msg)
         raise ValueError(msg) from exc
 
-    columns = {
-        "('#YY', '#yr')_('MM', 'mo')_('DD', 'dy')_('hh', 'hr')_('mm', 'mn')": "time"
-    }
-    columns.update({t: f"{t[0]} [{t[1]}]" for t in df.columns[1:]})
-    df = df.rename(index=str, columns=columns).set_index("time").sort_index()
+    df.set_index(df.columns[0], inplace=True)
+    df.index.rename("time", inplace=True)
+    df.sort_index(inplace=True)
     return df

--- a/moad_tools/observations.py
+++ b/moad_tools/observations.py
@@ -19,7 +19,7 @@
 """Functions for downloading observations data from web services.
 """
 import logging
-import urllib
+import urllib.error
 
 import pandas
 

--- a/moad_tools/observations.py
+++ b/moad_tools/observations.py
@@ -45,7 +45,7 @@ def get_ndbc_buoy(buoy_id):
     :rtype: :py:class:`pandas.DataFrame`
     """
     endpoint = "https://www.ndbc.noaa.gov/data/realtime2/"
-    msg = f"retrieving last 45 days of real-time buoy data from {endpoint}"
+    msg = f"retrieving available real-time buoy data from {endpoint}"
     try:
         buoy_number = int(buoy_id)
     except ValueError:

--- a/moad_tools/observations.py
+++ b/moad_tools/observations.py
@@ -71,9 +71,6 @@ def get_ndbc_buoy(buoy_id):
     logging.info(msg)
     ndbc_url = f"{endpoint}{buoy_number}.txt"
 
-    def datetime_parser(yr, mo, dy, hr, mn):
-        return datetime.strptime(f"{yr} {mo} {dy} {hr} {mn}", "%Y %m %d %H %M")
-
     try:
         try:
             df = pandas.read_csv(
@@ -82,7 +79,7 @@ def get_ndbc_buoy(buoy_id):
                 header=[0, 1],
                 na_values="MM",
                 parse_dates=[[0, 1, 2, 3, 4]],
-                date_parser=datetime_parser,
+                date_parser=lambda x: pandas.to_datetime(x, format="%Y %m %d %H %M"),
             )
         except urllib.error.URLError:
             # Work around SSL: UNKNOWN_PROTOCOL error that appeared on 23may18
@@ -94,7 +91,7 @@ def get_ndbc_buoy(buoy_id):
                 header=[0, 1],
                 na_values="MM",
                 parse_dates=[[0, 1, 2, 3, 4]],
-                date_parser=datetime_parser,
+                date_parser=lambda x: pandas.to_datetime(x, format="%Y %m %d %H %M"),
             )
     except urllib.error.HTTPError as exc:
         msg = (

--- a/moad_tools/observations.py
+++ b/moad_tools/observations.py
@@ -30,7 +30,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 def get_ndbc_buoy(buoy_id):
     """Retrieve a collection of time series of the last 45 days of real-time observed
-    buoy data for an ECCC or NOAA data buoyfrom the NOAA National Data Buoy Center (NDBC)
+    buoy data for an ECCC or NOAA data buoy from the NOAA National Data Buoy Center (NDBC)
     https://www.ndbc.noaa.gov/data/realtime2/ web service.
 
     The time series is returned as a :py:class:`pandas.DataFrame` object.


### PR DESCRIPTION
This addresses 2 critical issues that appeared sometime in pandas=1.2, 1.3, or 1.4:
* The way that the obs DataFrame index is set to date/time had to be overhauled due to
  `KeyError: "None of ['time'] are in the columns"`
* The date/time parsing methodology used in pandas.read_csv() was updated to address
   `FutureWarning: Use pd.to_datetime instead.`

A bunch of ther clean-ups are also included in this PR.