### PR TITLE
Add sphinx-notfound-page extension to docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,10 +1,12 @@
 version: 2
 
-# Only build HTML and JSON formats
-formats: []
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "mambaforge-4.10"
 
 conda:
   environment: envs/environment-rtd.yaml
 
-build:
-  image: latest
+# Only build HTML and JSON formats
+formats: []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ release = version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "notfound.extension",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",

--- a/envs/environment-dev.yaml
+++ b/envs/environment-dev.yaml
@@ -44,6 +44,7 @@ dependencies:
   # For documentation
   - sphinx
   - sphinx_rtd_theme
+  - sphinx-notfound-page
 
   - pip:
     # For unit tests

--- a/envs/environment-rtd.yaml
+++ b/envs/environment-rtd.yaml
@@ -15,3 +15,4 @@ dependencies:
   - pillow
   - sphinx
   - sphinx_rtd_theme
+  - sphinx-notfound-page

--- a/envs/environment-test.yaml
+++ b/envs/environment-test.yaml
@@ -31,6 +31,7 @@ dependencies:
   # For documentation links checking
   - sphinx
   - sphinx_rtd_theme
+  - sphinx-notfound-page
 
   - pip:
     # For unit tests


### PR DESCRIPTION
Ensures that static assets load in the event of a 404 for a better UX.
Facilitates future customization of 404 page.

Also bump readthedocs build OS to ubuntu-22.04 and change to use mambaforge-4.10 for build env.