### PR TITLE
Add Hatch wheel build target to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,5 +69,8 @@ branch = true
 source = [ "moad_tools", "tests"]
 
 
+[tool.hatch.build.targets.wheel]
+packages = ["moad_tools"]
+
 [tool.hatch.version]
 path = "moad_tools/__about__.py"


### PR DESCRIPTION
Hatchling 1.19.0 changed the package identification heuristics such that an explicit declaration of the code directory tree to build the wheel for installation from is now required.