### PR TITLE
Revise uses of `:kbd:` role in docs

### DIFF
--- a/docs/moad_tools.rst
+++ b/docs/moad_tools.rst
@@ -20,8 +20,8 @@
 :py:obj:`moad_tools` API
 ************************
 
-:kbd:`moad_tools.geo_tools` Module
-==================================
+:py:mod:`moad_tools.geo_tools` Module
+=====================================
 
 .. automodule:: moad_tools.geo_tools
     :members:
@@ -29,8 +29,8 @@
     :show-inheritance:
 
 
-:kbd:`moad_tools.observations` Module
-=====================================
+:py:mod:`moad_tools.observations` Module
+========================================
 
 .. automodule:: moad_tools.observations
     :members:
@@ -38,8 +38,8 @@
     :show-inheritance:
 
 
-:kbd:`moad_tools.places` Module
-===============================
+:py:mod:`moad_tools.places` Module
+==================================
 
 .. automodule:: moad_tools.places
     :members:
@@ -47,8 +47,8 @@
     :show-inheritance:
 
 
-:kbd:`moad_tools.midoss` Sub-package
-====================================
+:py:mod:`moad_tools.midoss` Sub-package
+=======================================
 
 :command:`geotiff-watermask` Tool
 ---------------------------------
@@ -121,9 +121,11 @@ The :ref:`RandomOilSpillsFunctionsAndCommand-lineInterface` section below provid
 Processing Configuration YAML File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A collection of values for the processing that the :command:`random-oil-spills` performs are stored in a YAML file that is passed in as the command-line argument :kbd:`CONFIG_FILE`.
+A collection of values for the processing that the :command:`random-oil-spills` performs
+are stored in a YAML file that is passed in as the command-line argument ``CONFIG_FILE``.
 
-In contrast to the :command:`random-oil-spills` command-line arguments :kbd:`N_SPILLS` and :kbd:`CSV_FILE` that may be different every time the script is run,
+In contrast to the :command:`random-oil-spills` command-line arguments ``N_SPILLS`` and
+``CSV_FILE`` that may be different every time the script is run,
 the values in the YAML file are likely to change only rarely.
 Storing them in a
 (version controlled)

--- a/moad_tools/midoss/geotiff_watermask.py
+++ b/moad_tools/midoss/geotiff_watermask.py
@@ -169,10 +169,10 @@ def cli(geotiff_file, meshmask_file, numpy_file, verbosity):
 
     :param str verbosity: Verbosity level of logging messages about the progress of the
                           transformation.
-                          Choices are :kbd:`debug, info, warning, error, critical`.
-                          :kbd:`warning`, :kbd:`error`, and :kbd:`critical` should be silent
-                          unless something bad goes wrong.
-                          Default is :kbd:`warning`.
+                          Choices are debug, info, warning, error, critical.
+                          The warning, error, and critical levels should be silent unless something
+                          bad goes wrong.
+                          Default is warning.
     """
     logging_level = getattr(logging, verbosity.upper())
     logging.basicConfig(

--- a/moad_tools/midoss/hdf5_to_netcdf4.py
+++ b/moad_tools/midoss/hdf5_to_netcdf4.py
@@ -438,10 +438,10 @@ def cli(hdf5_file, netcdf4_file, verbosity):
 
     :param str verbosity: Verbosity level of logging messages about the progress of the
                           transformation.
-                          Choices are :kbd:`debug, info, warning, error, critical`.
-                          :kbd:`warning`, :kbd:`error`, and :kbd:`critical` should be silent
-                          unless something bad goes wrong.
-                          Default is :kbd:`warning`.
+                          Choices are debug, info, warning, error, critical.
+                          The warning, error, and critical levels should be silent unless something
+                          bad goes wrong.
+                          Default is warning.
     """
     logging_level = getattr(logging, verbosity.upper())
     logging.basicConfig(

--- a/moad_tools/midoss/random_oil_spills.py
+++ b/moad_tools/midoss/random_oil_spills.py
@@ -19,21 +19,22 @@
 """Functions and command-line tool to calculate a CSV file containing parameters of a set
 of random oil spills to drive Monte Carlo runs of MOHID.
 """
+import collections
+import logging
+import sys
+from datetime import timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
 import arrow
 import click
-import collections
 import geopandas
-import logging
 import numpy
 import pandas
 import rasterio
 import shapely.geometry
-import sys
 import xarray
 import yaml
-from datetime import timedelta
-from pathlib import Path
-from types import SimpleNamespace
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
@@ -1626,10 +1627,10 @@ def cli(n_spills, config_file, csv_file, verbosity):
 
     :param str verbosity: Verbosity level of logging messages about the progress of the
                           transformation.
-                          Choices are :kbd:`debug, info, warning, error, critical`.
-                          :kbd:`warning`, :kbd:`error`, and :kbd:`critical` should be silent
-                          unless something bad goes wrong.
-                          Default is :kbd:`warning`.
+                          Choices are debug, info, warning, error, critical.
+                          The warning, error, and critical levels should be silent unless something
+                          bad goes wrong.
+                          Default is warning.
     """
     logging_level = getattr(logging, verbosity.upper())
     logging.basicConfig(

--- a/moad_tools/places.py
+++ b/moad_tools/places.py
@@ -19,7 +19,7 @@
 """UBC MOAD group geographic places information.
 
 It is recommended that library code that uses the :py:data:`PLACES` data
-structure from this module should use :kbd:`try...except` to catch
+structure from this module should use ``try...except`` to catch
 :py:exc:`KeyError` exceptions and produce an error message that is more
 informative than the default, for example:
 


### PR DESCRIPTION
Replaced `:kbd:` directives with inline code formatting or `:py:mod:` roles because the `:kbd:` role rendering has changed to look like key caps and that's not appropriate for most of the instances that it was being used for.

re: issue #46