### PR TITLE
Refine release notes package dev documentation

### DIFF
--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -580,7 +580,13 @@ The release process steps are:
 #. Push the version bump commit and tag to GitHub
 
 #. Use the GitHub web interface to create a release,
-   editing the auto-generated release notes as necessary
+   editing the auto-generated release notes into sections:
+
+   * Features
+   * Bug Fixes
+   * Documentation
+   * Maintenance
+   * Dependency Updates
 
 #. Use the GitHub :guilabel:`Issues -> Milestones` web interface to edit the release
    milestone:


### PR DESCRIPTION
Updated the guidance for editing GitHub release notes to organize them into categorized sections: Features, Bug Fixes, Documentation, Maintenance, and Dependency Updates. This ensures clearer and more consistent release notes.