### PR TITLE
Add `sphinx_copybutton` to docs

### DIFF
--- a/.github/workflows/pytest-no-midoss.yaml
+++ b/.github/workflows/pytest-no-midoss.yaml
@@ -35,6 +35,6 @@ jobs:
           environments: ${{ matrix.environment }}
 
       - name: Run pytest
-        run: pixi run -e ${{ matrix.environment }} pytest
+        run: pixi run -e ${{ matrix.environment }} pytest-no-midoss
 
       # Test coverage is not reported from this workflow because many tests are skipped.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ release = version
 # ones.
 extensions = [
     "notfound.extension",
+    "sphinx_copybutton",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,14 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 
+# -- Options for sphinx_copybutton extension ------------------------------
+
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+copybutton_line_continuation_character = "\\"
+# Add a `no-copybutton` class that can be used to suppress the copy button
+copybutton_selector = "div:not(.no-copybutton) > div.highlight > pre"
+
 intersphinx_mapping = {
     "mohidcmd": ("https://mohid-cmd.readthedocs.io/en/latest", None),
     "numpy": ("https://numpy.org/doc/1.18/", None),

--- a/docs/moad_tools.rst
+++ b/docs/moad_tools.rst
@@ -89,6 +89,7 @@ Information about the :command:`geotiff-watermask` command-line arguments and op
     $ pixi run -e midoss geotiff-watermask --help
 
 .. code-block:: text
+    :class: no-copybutton
 
     Usage: geotiff-watermask [OPTIONS] GEOTIFF_FILE MESHMASK_FILE NUMPY_FILE
 
@@ -137,6 +138,7 @@ Information about the :command:`hdf5-to-netcdf4` command-line arguments and opti
     $ pixi run -e midoss hdf5-to-netcdf4 --help
 
 .. code-block:: text
+    :class: no-copybutton
 
     Usage: hdf5-to-netcdf4 [OPTIONS] HDF5_FILE NETCDF4_FILE
 
@@ -171,6 +173,7 @@ Information about the :command:`random-oil-spills` command-line arguments and op
     $ pixi run -e midoss random-oil-spills --help
 
 .. code-block:: text
+    :class: no-copybutton
 
     Usage: random-oil-spills [OPTIONS] N_SPILLS CONFIG_FILE CSV_FILE
 

--- a/docs/moad_tools.rst
+++ b/docs/moad_tools.rst
@@ -84,9 +84,9 @@ used to generate oil spill parameters for Monte Carlo runs of MOHID.
 
 Information about the :command:`geotiff-watermask` command-line arguments and options is available via:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pixi run -e midoss geotiff-watermask --help
+    $ pixi run -e midoss geotiff-watermask --help
 
 .. code-block:: text
 
@@ -132,9 +132,9 @@ file into a netCDF4 file.
 
 Information about the :command:`hdf5-to-netcdf4` command-line arguments and options is available via:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pixi run -e midoss hdf5-to-netcdf4 --help
+    $ pixi run -e midoss hdf5-to-netcdf4 --help
 
 .. code-block:: text
 
@@ -166,9 +166,9 @@ Such a file is one of the items required to launch a collection of MOHID runs vi
 
 Information about the :command:`random-oil-spills` command-line arguments and options is available via:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pixi run -e midoss random-oil-spills --help
+    $ pixi run -e midoss random-oil-spills --help
 
 .. code-block:: text
 

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -161,12 +161,6 @@ That means that changes you make to the code are immediately reflected in the en
 
 .. _editable install mode: https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs
 
-To deactivate the environment use:
-
-.. code-block:: console
-
-    (moad-tools-dev)$ conda deactivate
-
 
 .. _moad_toolsCodingStyle:
 

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -102,7 +102,7 @@ Clone the code and documentation `repository`_ from GitHub with:
 
 .. _repository: https://github.com/UBC-MOAD/moad_tools
 
-.. code-block:: bash
+.. code-block:: console
 
     $ git clone git@github.com:UBC-MOAD/moad_tools.git
 
@@ -163,7 +163,7 @@ That means that changes you make to the code are immediately reflected in the en
 
 To deactivate the environment use:
 
-.. code-block:: bash
+.. code-block:: console
 
     (moad-tools-dev)$ conda deactivate
 
@@ -191,7 +191,7 @@ To install the `pre-commit` hooks in a newly cloned repo,
 activate the conda development environment,
 and run :command:`pre-commit install`:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd moad_tools
     $ pixi run -e dev pre-commit install
@@ -251,7 +251,7 @@ Building and Previewing the Documentation
 Building the documentation is driven by the :file:`docs/Makefile`.
 Use:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd moad_tools/
     $ pixi run docs
@@ -307,7 +307,7 @@ The HTML rendering of the docs ends up in :file:`docs/_build/html/`.
 You can open the :file:`index.html` file in that directory tree in your browser to preview the results of the build.
 To preview in Firefox from the command-line you can do:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ firefox docs/_build/html/index.html
 
@@ -327,7 +327,7 @@ Link Checking the Documentation
 Sphinx also provides a link checker utility which can be run to find broken or redirected links in the docs.
 Use:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd moad_tools/
     $ pixi run linkcheck
@@ -451,7 +451,7 @@ The `pytest`_ tool is used for test parametrization and as the test runner for t
 
 Use:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd moad_tools/
     $ pixi run -e test pytest
@@ -483,7 +483,7 @@ and `pytest-cov`_ tools with the command:
 .. _coverage.py: https://coverage.readthedocs.io/en/latest/
 .. _pytest-cov: https://pytest-cov.readthedocs.io/en/latest/
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd moad_tools/
     $ pixi run -e test pytest-cov
@@ -493,7 +493,7 @@ The test coverage report will be displayed below the test suite run output.
 Alternatively,
 you can use
 
-.. code-block:: bash
+.. code-block:: console
 
         $ pixi run -e test pytest-cov-html
 

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -260,6 +260,7 @@ to do a clean build of the documentation.
 The output looks something like:
 
 .. code-block:: text
+    :class: no-copybutton
 
     ✨ Pixi task (docs in docs): make clean html
     Removing everything under '_build'...
@@ -335,6 +336,7 @@ Use:
 The output looks something like:
 
 .. code-block:: text
+    :class: no-copybutton
 
     ✨ Pixi task (linkcheck in docs): make clean linkcheck
     Removing everything under '_build'...
@@ -460,6 +462,7 @@ to run the test suite.
 The output looks something like:
 
 .. code-block:: text
+    :class: no-copybutton
 
     ================================ test session starts ================================
     platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -826,6 +826,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-9.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-notfound-page-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
@@ -951,6 +952,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-9.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-notfound-page-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
@@ -1190,6 +1192,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-9.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-notfound-page-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
@@ -1444,6 +1447,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-9.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-notfound-page-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
@@ -1808,6 +1812,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-9.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-notfound-page-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
@@ -1862,6 +1867,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-9.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-notfound-page-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
@@ -1996,6 +2002,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-9.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-notfound-page-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
@@ -2145,6 +2152,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-9.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-notfound-page-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
@@ -13112,6 +13120,19 @@ packages:
   - pkg:pypi/sphinx?source=hash-mapping
   size: 1584836
   timestamp: 1767271941650
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_1.conda
+  sha256: 8cd892e49cb4d00501bc4439fb0c73ca44905f01a65b2b7fa05ba0e8f3924f19
+  md5: bf22cb9c439572760316ce0748af3713
+  depends:
+  - python >=3.9
+  - sphinx >=1.8
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/sphinx-copybutton?source=hash-mapping
+  run_exports: {}
+  size: 17893
+  timestamp: 1734573117732
 - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-notfound-page-1.1.0-pyhd8ed1ab_0.conda
   sha256: 227e87c72ff1e20833009f6ee6f9c1067534a92a14d8484619953d50f3c90f13
   md5: 08f13b15791e1b82ad8ad7d5b373ab54

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,18 +149,24 @@ pytest = ">=9.0.3,<10"
 python = "3.14.*"
 pytest = ">=9.0.3,<10"
 
+[tool.pixi.feature.test-py312-no-midoss.tasks]
+pytest-no-midoss = "pytest"
+
+[tool.pixi.feature.test-py313-no-midoss.tasks]
+pytest-no-midoss = "pytest"
+
 [tool.pixi.feature.test-py314-no-midoss.tasks]
 pytest-no-midoss = "pytest"
 
 [tool.pixi.feature.docs.dependencies]
 docutils = "0.22.4.*"
 sphinx = "9.1.0.*"
+sphinx-copybutton = ">=0.5.2,<0.6"
 sphinx-notfound-page = "1.1.0.*"
 commonmark = "0.9.1.*"
 recommonmark = "0.7.1.*"
 mock = "5.2.0.*"
 pillow = "12.2.0.*"
-sphinx-copybutton = ">=0.5.2,<0.6"
 
 [tool.pixi.feature.docs.tasks]
 docs = { cmd = "make clean html", cwd = "docs/" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ commonmark = "0.9.1.*"
 recommonmark = "0.7.1.*"
 mock = "5.2.0.*"
 pillow = "12.2.0.*"
+sphinx-copybutton = ">=0.5.2,<0.6"
 
 [tool.pixi.feature.docs.tasks]
 docs = { cmd = "make clean html", cwd = "docs/" }
@@ -189,6 +190,7 @@ geopandas = ">=1.1.3,<2"
 pytables = ">=3.11.1,<4"
 rasterio = ">=1.5.0,<2"
 shapely = ">=2.1.2,<3"
+sphinx-copybutton = ">=0.5.2,<0.6"
 
 [tool.pixi.feature.dev.tasks]
 update-reqs = "python -m pip list --format=freeze >> requirements.txt"

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ markdown-it-py==4.2.0
 MarkupSafe==3.0.3
 matplotlib==3.10.9
 mdurl==0.1.2
-moad_tools==25.2.dev0
+moad_tools==26.2.dev0
 mock==5.2.0
 more-itertools==11.1.0
 munkres==1.1.4
@@ -123,6 +123,7 @@ six==1.17.0
 snowballstemmer==3.1.1
 snuggs==1.4.7
 Sphinx==9.1.0
+sphinx-copybutton==0.5.2
 sphinx-notfound-page==1.1.0
 sphinx_rtd_theme==3.1.0
 sphinxcontrib-applehelp==2.0.0


### PR DESCRIPTION
### Summary

This pull request improves the project documentation by implementing the following changes:
- Added support for the `sphinx-copybutton` extension:
  - Enabled the extension in Sphinx configuration.
  - Configured its behavior to respect bash line continuation characters, set a prompt text regex, and suppress specific copy buttons.
- Migrated shell command examples to use `console` code blocks for better clarity.
- Updated dependency management:
  - Included `sphinx-copybutton` in the documentation and development dependencies.
  - Updated `pixi.lock` with this new requirement.
- Removed outdated instructions for deactivating Conda environments to improve accuracy.
- Updated the package and version listings in the recent development environment.

### Changes Made

- Modified documentation files and build configuration for improved functionality and clarity.
- Adjusted `pixi.lock` to include new dependencies.
- Added new configurations to the `Sphinx` documentation system.

Most of the changes were done by the PyCharm Junie agent.